### PR TITLE
Add fake website name as an optional field

### DIFF
--- a/templates/roll.html
+++ b/templates/roll.html
@@ -13,6 +13,12 @@
     <meta property="og:title" content="{{ title }}">
     <meta property="twitter:title" content="{{ title }}">
 
+    {% if website_name != None %}
+        <meta property="og:site_name" content="{{ website_name }}"/>
+    {% else %}
+        <meta property="og:site_name" content="Noordstar News"/>
+    {% endif %}
+
     {% if description != None %}
     <meta name="description" content="{{ description }}" />
     <meta property="og:description" content="{{ description }}" />
@@ -23,6 +29,7 @@
     <meta property="twitter:image" content="{{ image }}" />
     {% endif %}
     
+    <meta property="og:url" content="{{ domain }}/{{ link }}"/>
     <meta http-equiv="refresh" content="0; url = {{ domain }}/source/{{ link }}" />
 </head>
 


### PR DESCRIPTION
The Rickroll Generator is missing two relevant fields: ` og:url`  and `og:site_name` which can sometimes keep the links from rendering as preferred on platforms like Discord and Telegram.

As per request in #8, these will be added with a new optional field to give a custom website name. For this, however, the database needs a new column. The database needs basic version control to prevent data loss during updates.